### PR TITLE
fix: Add startingRect scroll position to cloned node.

### DIFF
--- a/src/interfaces/boundingRectangle.interface.ts
+++ b/src/interfaces/boundingRectangle.interface.ts
@@ -8,4 +8,6 @@ export interface BoundingRectangle {
   right: number;
   height?: number;
   width?: number;
+  scrollTop?: number;
+  scrollLeft?: number;
 }

--- a/src/resizable.directive.ts
+++ b/src/resizable.directive.ts
@@ -91,7 +91,9 @@ function getElementRect(element: ElementRef, ghostElementPositioning: string): B
       top: boundingRect.top,
       bottom: boundingRect.bottom,
       left: boundingRect.left,
-      right: boundingRect.right
+      right: boundingRect.right,
+      scrollTop: element.nativeElement.scrollTop,
+      scrollLeft: element.nativeElement.scrollLeft
     };
   }
 }
@@ -493,6 +495,8 @@ export class Resizable implements OnInit, OnDestroy, AfterViewInit {
         this.renderer.setStyle(currentResize.clonedNode, 'width', `${currentResize.startingRect.width}px`);
         this.renderer.setStyle(currentResize.clonedNode, 'cursor', getResizeCursor(currentResize.edges, resizeCursors));
         this.renderer.addClass(currentResize.clonedNode, RESIZE_GHOST_ELEMENT_CLASS);
+        currentResize.clonedNode.scrollTop = currentResize.startingRect.scrollTop;
+        currentResize.clonedNode.scrollLeft = currentResize.startingRect.scrollLeft;
       }
       this.zone.run(() => {
         this.resizeStart.emit({


### PR DESCRIPTION
This fixes an issue where elements that have been scrolled are losing their scroll position during resize. It takes the scrollTop and scrollLeft values of the original element and applies it to the ghost element.

I was going to write a test for it but I couldn't get Karma to run the already existing tests without detaching from Chrome, running out of memory, etc.  Perhaps someone could help me out with that task. :)