### PR TITLE
fix: allow translate3d transforms on getElementRect()

### DIFF
--- a/src/resizable.directive.ts
+++ b/src/resizable.directive.ts
@@ -100,8 +100,8 @@ function getElementRect(
     .map(property => style[property])
     .find(value => !!value);
   if (transform && transform.includes('translate')) {
-    translateX = transform.replace(/.*translate\((.*)px, (.*)px\).*/, '$1');
-    translateY = transform.replace(/.*translate\((.*)px, (.*)px\).*/, '$2');
+    translateX = transform.match(/translate3?d?\(\s*([^ ,]+)\s*,\s*([^ ,]+)\s*(,\s*([^ )]+)\s*)?\)/)[1];
+    translateY = transform.match(/translate3?d?\(\s*([^ ,]+)\s*,\s*([^ ,]+)\s*(,\s*([^ )]+)\s*)?\)/)[2];
   }
 
   if (ghostElementPositioning === 'absolute') {


### PR DESCRIPTION
As an example, angular meterial cdkDrag uses translate3d transform to move objects.

Changed the way to extract translateX & translateY to be able to work with 'translate' and 'translate3d' transforms.

original regex from https://stackoverflow.com/a/31658290/4478897